### PR TITLE
Implement methods related to random numbers

### DIFF
--- a/src/ProcSharp/ProcSharp.cs
+++ b/src/ProcSharp/ProcSharp.cs
@@ -344,7 +344,7 @@ namespace ProcSharpCore
 
         public static void RandomGaussian()
         {
-
+            throw new NotImplementedException();
         }
 
         public static void RandomSeed(int seed)
@@ -354,17 +354,17 @@ namespace ProcSharpCore
 
         public static void Noise()
         {
-
+            throw new NotImplementedException();
         }
 
         public static void NoiseDetail()
         {
-
+            throw new NotImplementedException();
         }
 
         public static void NoiseSeed()
         {
-
+            throw new NotImplementedException();
         }
 
         #endregion

--- a/src/ProcSharp/ProcSharp.cs
+++ b/src/ProcSharp/ProcSharp.cs
@@ -21,8 +21,6 @@ namespace ProcSharpCore
         private static SDL_Color fillColor;
         private static SDL_Color strokeColor;
 
-        private static Random internalRandom;
-
         #region PUBLIC_CONSTANTS
 
         /// <summary>
@@ -317,6 +315,8 @@ namespace ProcSharpCore
         #endregion
 
         #region Random
+
+        private static Random internalRandom;
 
         public static float Random(float hi)
         {

--- a/src/ProcSharp/ProcSharp.cs
+++ b/src/ProcSharp/ProcSharp.cs
@@ -21,7 +21,7 @@ namespace ProcSharpCore
         private static SDL_Color fillColor;
         private static SDL_Color strokeColor;
 
-        private static Random InternalRandom;
+        private static Random internalRandom;
 
         #region PUBLIC_CONSTANTS
 
@@ -325,12 +325,12 @@ namespace ProcSharpCore
                 return 0;
             }
 
-            if (InternalRandom == null)
+            if (internalRandom == null)
             {
-                InternalRandom = new Random();
+                internalRandom = new Random();
             }
 
-            return (float)InternalRandom.NextDouble() * hi;
+            return (float)internalRandom.NextDouble() * hi;
         }
 
         public static float Random(float lo, float hi)
@@ -344,15 +344,15 @@ namespace ProcSharpCore
 
         public static float RandomGaussian()
         {
-            if (InternalRandom == null)
+            if (internalRandom == null)
             {
-                InternalRandom = new Random();
+                internalRandom = new Random();
             }
 
             // Use the Box-Muller transform to create a random Gaussian sample.
             // Note that we assume mean = 0 and stDev = 1.
-            double uniRand1 = 1.0 - InternalRandom.NextDouble();
-            double uniRand2 = 1.0 - InternalRandom.NextDouble();
+            double uniRand1 = 1.0 - internalRandom.NextDouble();
+            double uniRand2 = 1.0 - internalRandom.NextDouble();
             double randGaussian = Math.Sqrt(-2.0 * Math.Log(uniRand1)) * Math.Sin(2.0 * Math.PI * uniRand2);
 
             return (float) randGaussian;
@@ -360,7 +360,7 @@ namespace ProcSharpCore
 
         public static void RandomSeed(int seed)
         {
-            InternalRandom = new Random(seed);
+            internalRandom = new Random(seed);
         }
 
         public static void Noise()

--- a/src/ProcSharp/ProcSharp.cs
+++ b/src/ProcSharp/ProcSharp.cs
@@ -21,6 +21,8 @@ namespace ProcSharpCore
         private static SDL_Color fillColor;
         private static SDL_Color strokeColor;
 
+        private static Random InternalRandom;
+
         #region PUBLIC_CONSTANTS
 
         /// <summary>
@@ -310,6 +312,59 @@ namespace ProcSharpCore
             destRect.w = (int)width;
             destRect.h = (int)height;
             SDL_RenderCopy(renderer, pimage.texture, IntPtr.Zero, ref destRect);
+        }
+
+        #endregion
+
+        #region Random
+
+        public static float Random(float hi)
+        {
+            if (hi == 0)
+            {
+                return 0;
+            }
+
+            if (InternalRandom == null)
+            {
+                InternalRandom = new Random();
+            }
+
+            return (float)InternalRandom.NextDouble() * hi;
+        }
+
+        public static float Random(float lo, float hi)
+        {
+            if (lo >= hi) return lo;
+
+            float diff = hi - lo;
+
+            return Random(diff) + lo;
+        }
+
+        public static void RandomGaussian()
+        {
+
+        }
+
+        public static void RandomSeed(int seed)
+        {
+            InternalRandom = new Random(seed);
+        }
+
+        public static void Noise()
+        {
+
+        }
+
+        public static void NoiseDetail()
+        {
+
+        }
+
+        public static void NoiseSeed()
+        {
+
         }
 
         #endregion

--- a/src/ProcSharp/ProcSharp.cs
+++ b/src/ProcSharp/ProcSharp.cs
@@ -318,6 +318,11 @@ namespace ProcSharpCore
 
         private static Random internalRandom;
 
+        /// <summary>
+        /// Returns a random float between 0 and a given upper bound.
+        /// </summary>
+        /// <param name="hi">The upper bound of the range.</param>
+        /// <returns>A random float between 0 and a given upper bound.</returns>
         public static float Random(float hi)
         {
             if (hi == 0)
@@ -333,6 +338,12 @@ namespace ProcSharpCore
             return (float) internalRandom.NextDouble() * hi;
         }
 
+        /// <summary>
+        /// Returns a random float between two given boundaries.
+        /// </summary>
+        /// <param name="lo">The lower bound of the range.</param>
+        /// <param name="hi">The upper bound of the range.</param>
+        /// <returns>A random float between two given boundaries.</returns>
         public static float Random(float lo, float hi)
         {
             if (lo >= hi) return lo;
@@ -342,6 +353,10 @@ namespace ProcSharpCore
             return Random(diff) + lo;
         }
 
+        /// <summary>
+        /// Returns a float from a random series of numbers having a mean of 0 and standard deviation of 1.
+        /// </summary>
+        /// <returns>A random float from a normal distribution with a mean of 0 and a standard deviation of 1.</returns>
         public static float RandomGaussian()
         {
             if (internalRandom == null)
@@ -349,7 +364,7 @@ namespace ProcSharpCore
                 internalRandom = new Random();
             }
 
-            // Use the Box-Muller transform to create a random Gaussian sample.
+            // Use the Box-Muller transform to produce a random Gaussian sample.
             // Note that we assume mean = 0 and stDev = 1.
             double uniRand1 = 1.0 - internalRandom.NextDouble();
             double uniRand2 = 1.0 - internalRandom.NextDouble();
@@ -358,6 +373,10 @@ namespace ProcSharpCore
             return (float) randGaussian;
         }
 
+        /// <summary>
+        /// Sets the seed value for the random generator used in the Random methods.
+        /// </summary>
+        /// <param name="seed">The seed with which the RNG will be initialized.</param>
         public static void RandomSeed(int seed)
         {
             internalRandom = new Random(seed);
@@ -375,17 +394,25 @@ namespace ProcSharpCore
         private static int perlinOctaves = 4; // PO = 4 results in "medium smooth" noise
         private static float perlinAmpFalloff = 0.5f;
 
+        // Shared Perlin variables
         private static int perlinTwopi, perlinPi;
         private static float[] perlinCosTable;
         private static float[] perlin;
 
         private static Random perlinRandom;
 
-        // Pre-calculate the cosine lookup table to improve performance
+        // Pre-calculate the cosine lookup table once in Noise(x, y, z) and reuse it afterwards to improve performance
         private static float[] cosLookupTable;
         private const float SinCosPrecision = 0.5f;
         private const int SinCosLength= (int) (360f / SinCosPrecision);
 
+        /// <summary>
+        /// Returns the Perlin noise value at specified coordinates.
+        /// </summary>
+        /// <param name="x">The x-coordinate in noise space.</param>
+        /// <param name="y">The y-coordinate in noise space.</param>
+        /// <param name="z">The z-coordinate in noise space.</param>
+        /// <returns>A float equal to the Perlin noise value at the specified x, y, and z coordinates.</returns>
         public static float Noise(float x, float y, float z)
         {
             if (cosLookupTable == null)
@@ -406,7 +433,7 @@ namespace ProcSharpCore
                 perlin = new float[PerlinSize + 1];
                 for (int i = 0; i < PerlinSize + 1; i++)
                 {
-                    perlin[i] = (float)perlinRandom.NextDouble();
+                    perlin[i] = (float) perlinRandom.NextDouble();
                 }
 
                 perlinCosTable = cosLookupTable;
@@ -414,6 +441,7 @@ namespace ProcSharpCore
                 perlinPi >>= 1;
             }
 
+            // Declare variables used in the Perlin noise algorithm
             if (x < 0) x = -x;
             if (y < 0) y = -y;
             if (z < 0) z = -z;
@@ -429,6 +457,7 @@ namespace ProcSharpCore
 
             float n1, n2, n3;
 
+            // Repeat the Perlin noise algorithm as many times as specified by the level of detail (perlinOctaves)
             for (int i = 0; i < perlinOctaves; i++)
             {
                 int of = xi + (yi << PerlinYWrapB) + (zi << PerlinZWrapB);
@@ -465,33 +494,61 @@ namespace ProcSharpCore
             return r;
         }
 
+        /// <summary>
+        /// Returns the Perlin noise value at specified x and y coordinates with z = 0.
+        /// </summary>
+        /// <param name="x">The x-coordinate in noise space.</param>
+        /// <param name="y">The y-coordinate in noise space.</param>
+        /// <returns>A float equal to the Perlin noise value at the specified x and y coordinates with z = 0.</returns>
         public static float Noise(float x, float y)
         {
             return Noise(x, y, 0f);
         }
 
+        /// <summary>
+        /// Returns the Perlin noise value at the specified x-coordinate with y = 0 and z = 0..
+        /// </summary>
+        /// <param name="x">The x-coordinate in noise space.</param>
+        /// <returns>A float equal to the Perlin noise value at the specified x, y, and z coordinates.</returns>
         public static float Noise(float x)
         {
             return Noise(x, 0f, 0f);
         }
 
+        /// <summary>
+        /// Returns a transformed version of cos(i) for a given float i for usage in the Perlin noise algorithm.
+        /// </summary>
+        /// <param name="i">The scalar by which pi will be multiplied in the transformation.</param>
+        /// <returns></returns>
         private static float NoiseFsc(float i)
         {
-            // Use Bagel's cosine table instead of the regular one
             return 0.5f * (1.0f - perlinCosTable[(int) (i * perlinPi) % perlinTwopi]);
         }
 
+        /// <summary>
+        /// Adjusts the level of detail produced by the Perlin noise function.
+        /// </summary>
+        /// <param name="levelOfDetail">The desired level of detail for the Perlin noise function.</param>
         public static void NoiseDetail(int levelOfDetail)
         {
             if (levelOfDetail > 0) perlinOctaves = levelOfDetail;
         }
 
+        /// <summary>
+        /// Adjusts the level of detail and character produced by the Perlin noise function.
+        /// </summary>
+        /// <param name="levelOfDetail">The desired level of detail for the Perlin noise function.</param>
+        /// <param name="falloff">The desired falloff factor for each octave of the level of detail.</param>
         public static void NoiseDetail(int levelOfDetail, float falloff)
         {
             if (levelOfDetail > 0) perlinOctaves = levelOfDetail;
             if (falloff > 0) perlinAmpFalloff = falloff;
         }
 
+        /// <summary>
+        /// Sets the seed value for the random generator used in the Noise methods.
+        /// </summary>
+        /// <param name="seed">The seed with which the random generator will be initialized.</param>
         public static void NoiseSeed(int seed)
         {
             perlinRandom = new Random(seed);

--- a/src/ProcSharp/ProcSharp.cs
+++ b/src/ProcSharp/ProcSharp.cs
@@ -342,9 +342,20 @@ namespace ProcSharpCore
             return Random(diff) + lo;
         }
 
-        public static void RandomGaussian()
+        public static float RandomGaussian()
         {
-            throw new NotImplementedException();
+            if (InternalRandom == null)
+            {
+                InternalRandom = new Random();
+            }
+
+            // Use the Box-Muller transform to create a random Gaussian sample.
+            // Note that we assume mean = 0 and stDev = 1.
+            double uniRand1 = 1.0 - InternalRandom.NextDouble();
+            double uniRand2 = 1.0 - InternalRandom.NextDouble();
+            double randGaussian = Math.Sqrt(-2.0 * Math.Log(uniRand1)) * Math.Sin(2.0 * Math.PI * uniRand2);
+
+            return (float) randGaussian;
         }
 
         public static void RandomSeed(int seed)


### PR DESCRIPTION
This PR addresses issue #3.

Where possible, the methods were implemented like they were in the original Processing library. The RandomGaussian() method is a slight exception, because C#'s built-in Random() object does not support a NextGaussian() method. Therefore, I replicated the original library's functionality by implementing the Box-Muller transform to obtain the same result.

The implemented methods were tested on a case-by-case basis. The returned values from Random(), RandomGaussian(), Noise(), and related variants all seem to stay within the desired range.